### PR TITLE
Yang Plugin updates for Openconfig files

### DIFF
--- a/YANG-to-Redfish-Plugin/redfish.py
+++ b/YANG-to-Redfish-Plugin/redfish.py
@@ -40,10 +40,10 @@ class RedfishPlugin(plugin.PyangPlugin):
                                  dest="create_groupings",
                                  action="store_true",
                                  help="Create XML definitions for grouping definitions pulled by uses"),
-            optparse.make_option("--remove_cyclical_imports",
-                                 dest="remove_cyclical_imports",
+            optparse.make_option("--keep_cyclical_imports",
+                                 dest="keep_cyclical_imports",
                                  action="store_true",
-                                 help="Remove possible cyclical imports to module xml"),
+                                 help="Keep possible cyclical imports to module xml"),
             optparse.make_option("--combine_all_nodes",
                                  dest="combine_all_nodes",
                                  action="store_true",
@@ -69,8 +69,8 @@ class RedfishPlugin(plugin.PyangPlugin):
         list_of_xml = []
         target_dir = ctx.opts.target_dir if ctx.opts.target_dir is not None else './output_dir'
 
-        if ctx.opts.remove_cyclical_imports:
-            csdltree.config['remove_cyclical'] = True
+        if ctx.opts.keep_cyclical_imports:
+            csdltree.config['remove_cyclical'] = False
 
         if ctx.opts.combine_all_nodes:
             csdltree.config['single_file'] = True

--- a/YANG-to-Redfish-Plugin/redfish.py
+++ b/YANG-to-Redfish-Plugin/redfish.py
@@ -36,6 +36,10 @@ class RedfishPlugin(plugin.PyangPlugin):
             optparse.make_option("--target_dir",
                                  dest="target_dir",
                                  help="Where to output xml files"),
+            optparse.make_option("--create_groupings",
+                                 dest="create_groupings",
+                                 action="store_true",
+                                 help="Create XML definitions for grouping definitions pulled by uses"),
             optparse.make_option("--remove_cyclical_imports",
                                  dest="remove_cyclical_imports",
                                  action="store_true",
@@ -70,6 +74,9 @@ class RedfishPlugin(plugin.PyangPlugin):
 
         if ctx.opts.combine_all_nodes:
             csdltree.config['single_file'] = True
+
+        if ctx.opts.create_groupings:
+            csdltree.config['no_groupings'] = False
 
         if not os.path.exists(target_dir):
             os.makedirs(target_dir)

--- a/YANG-to-Redfish-Plugin/rf/csdltree.py
+++ b/YANG-to-Redfish-Plugin/rf/csdltree.py
@@ -22,7 +22,7 @@ all_imports = {}
 config = {
         'single_file': False,
         'no_groupings': True,
-        'remove_cyclical': False,
+        'remove_cyclical': True,
         }
 
 def setLogger(mylogger):

--- a/YANG-to-Redfish-Plugin/rf/csdltree.py
+++ b/YANG-to-Redfish-Plugin/rf/csdltree.py
@@ -6,7 +6,7 @@ import rf.redfishtypes as redfishtypes
 import rf.statement_handlers as handlers
 import rf.xml_convenience as xml_convenience
 from rf.xml_content import XMLContent
-from xml.etree.ElementTree import Element, SubElement
+from xml.etree.ElementTree import Element, SubElement, tostring
 
 # This file contains the build_tree function and handlers
 # for YANG statements that would result in the build_tree being
@@ -21,6 +21,7 @@ all_imports = {}
 
 config = {
         'single_file': False,
+        'no_groupings': True,
         'remove_cyclical': False,
         }
 
@@ -105,6 +106,9 @@ def createCollectionXML(name, prefix='', xml_node=None):
     xml_convenience.add_annotation(collection_target, {"Term": "OData.Description",
         "String": "A Collection of " + name + " resource instances."
         })
+    xml_convenience.add_annotation(collection_target, {"Term": "OData.LongDescription",
+        "String": "A Collection of " + name + " resource instances."
+        })
     xml_convenience.add_collection_annotation(collection_target, {"Term":
         "Capabilities.InsertRestrictions"}, {"Insertable": "false"})
     xml_convenience.add_collection_annotation(collection_target, {"Term":
@@ -120,6 +124,7 @@ def createCollectionXML(name, prefix='', xml_node=None):
     xml_convenience.add_annotation(nav_prop, {'Term':'OData.Permissions',
         'EnumMember':'OData.Permissions/Read'})
     xml_convenience.add_annotation(nav_prop, {'Term':'OData.Description', 'String':'Contains members of this collection.'})
+    xml_convenience.add_annotation(nav_prop, {'Term':'OData.LongDescription', 'String':'Contains members of this collection.'})
     xml_convenience.add_annotation(nav_prop, {'Term':'OData.AutoExpandReferences'})
     return collection_xml_root
 
@@ -141,15 +146,14 @@ def create_xml_base(csdlname, prefix='', xml_node = None):
         'Namespace', prefix + csdlname + ".v1_0_0")
     schema_node.set(
         'xmlns', 'http://docs.oasis-open.org/odata/ns/edm')
-    xml_convenience.add_annotation(schema_node, {"Term":
-        "Redfish.OwningEntity", "String": "DMTF"})
+    xml_convenience.add_annotation(schema_node, {"Term": "Redfish.OwningEntity", "String": "DMTF"})
+    xml_convenience.add_annotation(schema_node, {"Term": "Redfish.Release", "String": "TBD"})
     # add in first schema
     schema_node_og = Element('Schema')
     schema_node_og.set('Namespace', prefix + csdlname)
     schema_node_og.set(
         'xmlns', 'http://docs.oasis-open.org/odata/ns/edm')
-    xml_convenience.add_annotation(schema_node_og, {"Term":
-        "Redfish.OwningEntity", "String": "DMTF"})
+    xml_convenience.add_annotation(schema_node_og, {"Term": "Redfish.OwningEntity", "String": "DMTF"})
     data_services_node.insert(0, schema_node_og)
 
     schema1_entity = SubElement(schema_node_og, 'EntityType')
@@ -185,6 +189,7 @@ def build_tree(yang_item, list_of_xml, xlogger, prefix="", topleveltypes=None, t
         toplevelimports = all_imports
 
     if seg_type in ['module','submodule', 'container', 'list', 'grouping']:
+        # input((seg_type, name))
         csdlname = handlers.get_valid_csdl_identifier(name)
 
         if len(current_xml_top) > 0 and config['single_file']:
@@ -245,11 +250,16 @@ def build_tree(yang_item, list_of_xml, xlogger, prefix="", topleveltypes=None, t
         schema_node.append(entity_node)
         main_node.remove(data_services_node)
         if not config['single_file'] or (config['single_file'] and len(current_xml_top) == 1):
-            main_node.append(data_services_node)
-            xml_content = XMLContent()
-            xml_content.set_filename(filename)
-            xml_content.set_xml(main_node)
-            list_of_xml.append(xml_content)
+            if seg_type == 'grouping' and config['no_groupings']:
+                parent_of = filename.split('_v1.xml')[0]
+                new_list = [x for x in list_of_xml if parent_of in x.filename]
+                _temp = [list_of_xml.remove(x) for x in new_list]
+            else:
+                main_node.append(data_services_node)
+                xml_content = XMLContent()
+                xml_content.set_filename(filename)
+                xml_content.set_xml(main_node)
+                list_of_xml.append(xml_content)
 
         current_xml_top.pop()
 
@@ -281,8 +291,7 @@ def build_tree(yang_item, list_of_xml, xlogger, prefix="", topleveltypes=None, t
             prop_node.set(
                 'Type', 'Collection({}.{})'.format(prefix + "v1_0_0", csdlname))
             xml_convenience.add_annotation(prop_node, {"Term": "OData.LongDescription",
-                    "String": "List of the type {}.".format(csdlname)}
-                    )
+                    "String": "List of the type {}.".format(csdlname)})
             our_parent = parent_schema
 
         if seg_type == 'anyxml':

--- a/YANG-to-Redfish-Plugin/rf/redfishtypes.py
+++ b/YANG-to-Redfish-Plugin/rf/redfishtypes.py
@@ -13,13 +13,13 @@ types_mapping = {
     'empty':             'RedfishYang.empty',  # clause
     'enumeration':       'Edm.EnumType',  # clause
     'identityref':       'RedfishYang.instance_identifier',  # clause
-    'int8':              'Edm.Sbyte',
+    'int8':              'Edm.Int16',
     'int16':             'Edm.Int16',
     'int32':             'Edm.Int32',
     'int64':             'Edm.Int64',
     'leafref':           'Edm.String',  # clause
     'string':            'Edm.String',
-    'uint8':             'Edm.Int16',
+    'uint8':             'RedfishYang.uint16',
     'uint16':            'RedfishYang.uint16',
     'uint32':            'RedfishYang.uint32',
     'uint64':            'RedfishYang.uint64',

--- a/YANG-to-Redfish-Plugin/rf/redfishtypes.py
+++ b/YANG-to-Redfish-Plugin/rf/redfishtypes.py
@@ -5,8 +5,8 @@
 import string
 
 types_mapping = {
-    'binary':            'Edm.Binary',
-    'bits':              'Edm.Binary',
+    'binary':            'Edm.Int32',
+    'bits':              'Edm.Int32',
     'boolean':           'Edm.Boolean',
     'date_and_time':     'Edm.DateTimeOffset',
     'decimal64':         'Edm.Decimal',
@@ -19,7 +19,7 @@ types_mapping = {
     'int64':             'Edm.Int64',
     'leafref':           'Edm.String',  # clause
     'string':            'Edm.String',
-    'uint8':             'Edm.Byte',
+    'uint8':             'Edm.Int16',
     'uint16':            'RedfishYang.uint16',
     'uint32':            'RedfishYang.uint32',
     'uint64':            'RedfishYang.uint64',

--- a/YANG-to-Redfish-Plugin/rf/statement_handlers.py
+++ b/YANG-to-Redfish-Plugin/rf/statement_handlers.py
@@ -331,11 +331,14 @@ def handle_type(type_tag, xml_node, parent_node, parent_entity, imports, types):
                 if var_type in rf.csdltree.types_created_by_import[module]:
                     importname = module
                     break
-            if imports[importname] != top_name:
-                ns = get_valid_csdl_identifier(imports[importname]) + '.v1_0_0'
-                xml_convenience.add_import(xml_top, get_valid_csdl_identifier(imports[importname]), importname if importname != imports[importname] else None, ns)
+            imported_name = imports.get(importname, 'MissingTypeName') # backup
+            if imported_name != top_name:
+                ns = get_valid_csdl_identifier(imported_name) + '.v1_0_0'
+                xml_convenience.add_import(xml_top,
+                        get_valid_csdl_identifier(imported_name),
+                        importname if importname != imported_name else None, ns)
             else:
-                importname = get_valid_csdl_identifier(imports[importname]) + '.v1_0_0'
+                importname = get_valid_csdl_identifier(imported_name) + '.v1_0_0'
             yang_type_location = importname
             annotation.set('Term', '{}.YangType'.format(yang_type_location))
             var_type = importname + '.' + redfishtypes.types_mapping.get(var_type, var_type)

--- a/YANG-to-Redfish-Plugin/rf/statement_handlers.py
+++ b/YANG-to-Redfish-Plugin/rf/statement_handlers.py
@@ -326,11 +326,12 @@ def handle_type(type_tag, xml_node, parent_node, parent_entity, imports, types):
             importname = var_type.split(':')[0]
             if importname in imports and imports[importname] != top_name:
                 ns = get_valid_csdl_identifier(imports[importname]) + '.v1_0_0'
-                xml_convenience.add_import(xml_top, get_valid_csdl_identifier(imports[importname]), importname if importname != imports[importname] else None, ns)
+                xml_convenience.add_import(xml_top, get_valid_csdl_identifier(imports[importname]),
+                    get_valid_csdl_identifier(importname) if importname != imports[importname] else None, ns)
             elif importname in imports:
                 importname = get_valid_csdl_identifier(imports[importname]) + '.v1_0_0'
                 var_type = importname + ':' + var_type.split(':')[1]
-            yang_type_location = importname
+            yang_type_location = get_valid_csdl_identifier(importname)
             annotation.set('Term', '{}.YangType'.format(yang_type_location))
             var_type = redfishtypes.types_mapping.get(var_type, var_type)
 
@@ -347,12 +348,15 @@ def handle_type(type_tag, xml_node, parent_node, parent_entity, imports, types):
                 ns = get_valid_csdl_identifier(imported_name) + '.v1_0_0'
                 xml_convenience.add_import(xml_top,
                         get_valid_csdl_identifier(imported_name),
-                        importname if importname != imported_name else None, ns)
-            else:
-                importname = get_valid_csdl_identifier(imported_name) + '.v1_0_0'
-            yang_type_location = importname
+                        get_valid_csdl_identifier(importname) if importname != imported_name else None, ns)
+            yang_type_location = get_valid_csdl_identifier(importname)
             annotation.set('Term', '{}.YangType'.format(yang_type_location))
-            var_type = importname + '.' + redfishtypes.types_mapping.get(var_type, var_type)
+
+            if (importname in imports):
+                var_type = get_valid_csdl_identifier(imports[importname])+ '.v1_0_0.' + \
+                    get_valid_csdl_identifier( redfishtypes.types_mapping.get(var_type, var_type) )
+            else:
+                var_type = get_valid_csdl_identifier(importname) + '.v1_0_0.' + get_valid_csdl_identifier( redfishtypes.types_mapping.get(var_type, var_type) )
 
         elif var_type in types:
             # If we haven't defined this type, this must be added to imports
@@ -427,7 +431,7 @@ def handle_type(type_tag, xml_node, parent_node, parent_entity, imports, types):
         xml_node.remove(new_annotation)
         types[td] = nmd
 
-    annotation.set('EnumMember', yang_type_location + '.YangTypes/' + get_valid_csdl_identifier(yang_type.split(':')[-1]))
+    annotation.set('EnumMember', get_valid_csdl_identifier(yang_type_location) + '.YangTypes/' + get_valid_csdl_identifier(yang_type.split(':')[-1]))
     xml_node.append(annotation)
 
     return annotation


### PR DESCRIPTION
Add fixes to the plugin that resolves resolution issues when generating multiple CSDL, and fixes to generating a single CSDL file, which now passes modified test regiment in `spmf` repository.

Removed generation of groupings/uses statements, as they're definitions but not resources.

Resolved typing resolutions for enumerations in groupings.